### PR TITLE
fix: cache not replicating 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 }
 
-version "0.2"
+version "0.2.1"
 group "cat.dipta.plugins"
 
 apply plugin:"eclipse"
@@ -35,8 +35,8 @@ dependencies {
 
     compile 'org.xbib.groovy:groovy-crypt:1.0.0'
 
-    compile 'org.infinispan:infinispan-core:8.2.4.Final'
-    compile 'org.infinispan:infinispan-commons:8.2.4.Final'
+    compileOnly 'org.infinispan:infinispan-core:8.2.4.Final'
+    compileOnly 'org.infinispan:infinispan-commons:8.2.4.Final'
 
     testCompile "org.grails.plugins:gsp"
     testCompile "org.grails:grails-gorm-testing-support"
@@ -64,11 +64,10 @@ bootRun {
 //}
 
 //Needed for Wildfly to load the infinispan dependencies
-
 jar {
     manifest {
         attributes (
-                'Dependencies': 'org.infinispan export'
+                'Dependencies': 'org.infinispan, org.infinispan.commons, org.jboss.as.clustering.infinispan export'
         )
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>cat.dipta.plugins</groupId>
   <artifactId>cache-custom</artifactId>
-  <version>0.1</version>
+  <version>0.2.1</version>
   <dependencies>
     <dependency>
       <groupId>org.grails.plugins</groupId>

--- a/src/main/groovy/grails/plugin/cache/custom/infinispan/InfiniCacheManager.groovy
+++ b/src/main/groovy/grails/plugin/cache/custom/infinispan/InfiniCacheManager.groovy
@@ -2,6 +2,8 @@ package grails.plugin.cache.custom.infinispan
 
 import groovy.util.logging.Slf4j
 import org.grails.plugin.cache.GrailsCacheManager
+import org.infinispan.configuration.cache.CacheMode
+import org.infinispan.configuration.cache.ConfigurationBuilder
 import org.infinispan.manager.EmbeddedCacheManager
 import org.springframework.cache.Cache
 
@@ -16,7 +18,7 @@ class InfiniCacheManager implements GrailsCacheManager
     InfiniCacheManager(CacheConfig config)
     {
         manager = config.manager
-        log.debug("Get existing caches")
+        log.debug("Retrieve existing caches")
         manager.getCacheNames().each { name ->
             def cache = new InfiniCache(name, manager.getCache(name))
             cacheMap.put(name, cache)
@@ -58,10 +60,11 @@ class InfiniCacheManager implements GrailsCacheManager
         manager.getCacheNames()
     }
 
-
     protected InfiniCache createCache(String name)
     {
-        log.debug("Create cache $name")
-        new InfiniCache(name, manager.getCache(name))
+        log.debug("Creating a new cache: $name")
+
+        //Create a new cache applying the configuration retrieved from the default cache
+        new InfiniCache(name, manager.getCache(name,'default'))
     }
 }

--- a/src/main/groovy/grails/plugin/cache/custom/infinispan/WildflyCacheConfig.groovy
+++ b/src/main/groovy/grails/plugin/cache/custom/infinispan/WildflyCacheConfig.groovy
@@ -2,6 +2,7 @@ package grails.plugin.cache.custom.infinispan
 
 import grails.config.Config
 import groovy.util.logging.Slf4j
+import org.infinispan.Cache
 import org.infinispan.manager.EmbeddedCacheManager
 
 import javax.naming.Context
@@ -14,17 +15,37 @@ class WildflyCacheConfig implements CacheConfig
 
     WildflyCacheConfig(Config config)
     {
-        def jdniURI = config.getProperty('grails.cache.custom.wildfly.jdni', String)
-        log.info("JDNI: $jdniURI")
+        String jdniContainer = config.getProperty('grails.cache.custom.wildfly.jdni', String)
 
-        if (jdniURI == null)
+        if (jdniContainer == null)
             throw new RuntimeException("Please provide a JDNI URI for the Wildfly Infinispan cache container")
 
+        log.info("Container JDNI: $jdniContainer")
+
+        String jdniCache = config.get('grails.cache.custom.wildfly.default', String)
+
+        if (jdniCache == null)
+            throw new RuntimeException("Please provide a JDNI URI for the Wildfly Infinispan default cache")
+
+        log.info("Default Cache JDNI: $jdniCache")
+
+        Context context = new InitialContext()
+        Cache defaultCache
+
         try {
-            Context context = new InitialContext()
-            manager = (EmbeddedCacheManager) context.lookup(jdniURI)
-            log.info("Cache manager acquired")
-        } catch( Exception ex)
+             defaultCache = (Cache) context.lookup(jdniCache)
+
+        } catch(Exception ex)
+        {
+            log.error(ex.message)
+            throw new RuntimeException("Please provide a valid JDNI for the Wildfly Infinispan Default Cache")
+        }
+
+        try {
+            manager = (EmbeddedCacheManager) context.lookup(jdniContainer)
+            manager.defineConfiguration('default', defaultCache.getCacheConfiguration())
+            log.info('Default cache configuration retrieved')
+        } catch(Exception ex)
         {
             log.error(ex.message)
             throw new RuntimeException("Please provide a valid JDNI for the Wildfly Infinispan cache container")


### PR DESCRIPTION
Retrieves the configuration from the default cache in the cache container and applies it to each new created cache. 

Resolves jar issue with plugin/container infinispan jars.
